### PR TITLE
Fix displayName property in types and usage

### DIFF
--- a/frontend/src/components/messages/MessageListItem.tsx
+++ b/frontend/src/components/messages/MessageListItem.tsx
@@ -20,7 +20,7 @@ const MessageListItem: React.FC<MessageListItemProps> = ({ message }) => {
       <Box sx={styles.messageContents}>
         <Box sx={styles.headerContainer}>
           <Typography sx={styles.username} color="textSecondary">
-            {message.user?.displayname || message.user?.username}
+            {message.user?.displayName || message.user?.username}
           </Typography>
           <Typography sx={styles.timestamp} color="textSecondary">
             {new Date(message.createdAt).toLocaleTimeString([], {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -6,7 +6,7 @@ export interface User {
   updatedAt: string;
   avatar?: string;
   isOnline?: boolean;
-  displayname?: string;
+  displayName?: string;
 }
 
 export interface Room {


### PR DESCRIPTION
## Summary
- rename `displayname` to `displayName` in user type
- update `MessageListItem` to use the new field

## Testing
- `npx tsc -p frontend/tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'body-parser', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6850ba0d55748325906f2e5bec101368