### PR TITLE
Link room ownership to user

### DIFF
--- a/backend/src/entities/room.entity.ts
+++ b/backend/src/entities/room.entity.ts
@@ -3,11 +3,14 @@ import {
   CreateDateColumn,
   Entity,
   OneToMany,
+  ManyToOne,
+  JoinColumn,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
 import { RoomMembership } from './room-membership.entity';
 import { Message } from './message.entity';
+import { User } from './user.entity';
 
 @Entity('room')
 export class Room {
@@ -16,6 +19,10 @@ export class Room {
 
   @Column({ name: 'owner_id', nullable: false })
   ownerId: string;
+
+  @ManyToOne(() => User, (user) => user.ownedRooms)
+  @JoinColumn({ name: 'owner_id' })
+  owner: User;
 
   @Column({ name: 'title', nullable: false })
   title: string;

--- a/backend/src/entities/user.entity.ts
+++ b/backend/src/entities/user.entity.ts
@@ -64,6 +64,6 @@ export class User {
   @OneToMany(() => Message, (message) => message.user)
   messages: Message[];
 
-  @OneToMany(() => Room, (room) => room.ownerId)
+  @OneToMany(() => Room, (room) => room.owner)
   ownedRooms: Room[];
 }


### PR DESCRIPTION
## Summary
- link `Room` to `User` via `owner` relation
- update `User` entity property mapping

## Testing
- `npm run build` *(fails: `nest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6850ba1a24c88325979854aae021fe2b