### PR TITLE
Implement stricter room title validation

### DIFF
--- a/frontend/src/components/rooms/NewRoomForm.tsx
+++ b/frontend/src/components/rooms/NewRoomForm.tsx
@@ -10,6 +10,7 @@ import { Modal } from '@/components/common/Modal';
 import { useCreateRoomMutation } from '@/services/room';
 import { closeModal } from '@/slices/modalSlice';
 import { useAppDispatch } from '@/store';
+import { validateRoomTitle } from '@/utils/validateRoomTitle';
 
 const NewRoomForm: React.FC = () => {
   const dispatch = useAppDispatch();
@@ -19,19 +20,7 @@ const NewRoomForm: React.FC = () => {
 
   const [createRoom] = useCreateRoomMutation();
 
-  const validateTitle = (value: string): { isValid: boolean; errorMessage: string | null } => {
-    if (!value.trim()) {
-      return { isValid: false, errorMessage: "Don't forget your title!" };
-    }
-
-    if (!value.match(/[a-zA-Z0-9]/g)) {
-      return { isValid: false, errorMessage: 'Please input more than just symbols/spaces' };
-    }
-
-    return { isValid: true, errorMessage: null };
-  };
-
-  const validation = touched ? validateTitle(title) : { isValid: false, errorMessage: null };
+  const validation = touched ? validateRoomTitle(title) : { isValid: false, errorMessage: null };
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setTitle(e.target.value);

--- a/frontend/src/utils/validateRoomTitle.ts
+++ b/frontend/src/utils/validateRoomTitle.ts
@@ -1,0 +1,18 @@
+export const validateRoomTitle = (
+  value: string,
+): { isValid: boolean; errorMessage: string | null } => {
+  if (!value.trim()) {
+    return { isValid: false, errorMessage: "Don't forget your title!" };
+  }
+
+  const ruleRegex = /^[a-z0-9_]+$/;
+  if (!ruleRegex.test(value) || value.length > 22) {
+    return {
+      isValid: false,
+      errorMessage:
+        'Names must be lowercase, without spaces or periods, and shorter than 22 characters.',
+    };
+  }
+
+  return { isValid: true, errorMessage: null };
+};

--- a/frontend/test/validateRoomTitle.test.ts
+++ b/frontend/test/validateRoomTitle.test.ts
@@ -1,0 +1,24 @@
+import { validateRoomTitle } from '../src/utils/validateRoomTitle';
+
+describe('validateRoomTitle', () => {
+  it('rejects empty values', () => {
+    expect(validateRoomTitle('').isValid).toBe(false);
+  });
+
+  it('accepts valid lowercase names', () => {
+    expect(validateRoomTitle('valid_name').isValid).toBe(true);
+  });
+
+  it('rejects uppercase letters', () => {
+    expect(validateRoomTitle('Invalid').isValid).toBe(false);
+  });
+
+  it('rejects spaces or periods', () => {
+    expect(validateRoomTitle('bad name').isValid).toBe(false);
+    expect(validateRoomTitle('bad.name').isValid).toBe(false);
+  });
+
+  it('rejects names longer than 22 characters', () => {
+    expect(validateRoomTitle('a'.repeat(23)).isValid).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- enforce lowercase letter/number/underscore rule in room title validation
- export validation logic into util file
- add basic Jest test for validation rules

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6850ba33e30483258cb9110fdb48e452