### PR TITLE
Fix refresh 401 by prefixing API routes

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -6,6 +6,7 @@ import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.setGlobalPrefix('api');
   app.enableCors();
   app.useGlobalPipes(new ValidationPipe());
   app.useWebSocketAdapter(new IoAdapter(app));

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -2,10 +2,13 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
 import { LoginResponse, LoginRequest, RegisterResponse, RegisterRequest } from '../types';
 
+const baseUrl =
+  (process.env.REACT_APP_BACKEND_URL || 'http://localhost:3000') + '/api';
+
 export const authApi = createApi({
   reducerPath: 'authApi',
   baseQuery: fetchBaseQuery({
-    baseUrl: process.env.REACT_APP_BACKEND_URL || 'http://localhost:3000',
+    baseUrl,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     prepareHeaders: (headers, { getState }: { getState: () => any }) => {
       // Get the token from auth state

--- a/frontend/src/services/room.ts
+++ b/frontend/src/services/room.ts
@@ -2,10 +2,13 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
 import { Room } from '../types';
 
+const baseUrl =
+  (process.env.REACT_APP_BACKEND_URL || 'http://localhost:3000') + '/api';
+
 export const roomApi = createApi({
   reducerPath: 'roomApi',
   baseQuery: fetchBaseQuery({
-    baseUrl: process.env.REACT_APP_BACKEND_URL || 'http://localhost:3000',
+    baseUrl,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     prepareHeaders: (headers, { getState }: { getState: () => any }) => {
       // Get the token from auth state

--- a/frontend/src/services/user.ts
+++ b/frontend/src/services/user.ts
@@ -20,10 +20,13 @@ interface ChangePasswordDto {
 }
 
 // Create the API with RTK Query
+const baseUrl =
+  (process.env.REACT_APP_BACKEND_URL || 'http://localhost:3000') + '/api';
+
 export const userApi = createApi({
   reducerPath: 'userApi',
   baseQuery: fetchBaseQuery({
-    baseUrl: process.env.REACT_APP_BACKEND_URL || 'http://localhost:3000',
+    baseUrl,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     prepareHeaders: (headers, { getState }: { getState: () => any }) => {
       // Get the token from auth state


### PR DESCRIPTION
## Summary
- prefix all backend routes with `/api`
- update frontend RTK Query base URLs to include the new prefix

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ff4a41cc8325a6f7e58f01e35bc4